### PR TITLE
modify the convert_gff_to_gbk.py function and deps

### DIFF
--- a/bin/processes.py
+++ b/bin/processes.py
@@ -5,6 +5,7 @@ from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 import pandas as pd
 import logging
+from BCBio import GFF
 
 def write_to_log(s, logger):
            while True:
@@ -160,12 +161,20 @@ def run_mmseqs(db_dir, out_dir, threads, logger, gene_predictor, evalue):
     sp.run(["rm", "-r", target_db_dir], check=True)
 
 
+# def convert_gff_to_gbk(fasta_input, out_dir, prefix, logger):
+#     gff_file = os.path.join(out_dir, prefix + ".gff")
+#     out_pref = os.path.join(out_dir, prefix)
+#     seqret = sp.Popen(["seqret", "-sequence", fasta_input, "-feature", "-fformat", "gff", "-fopenfile", gff_file, "-osformat", "genbank", "-osname_outseq", out_pref, "-auto"], stderr=sp.PIPE)
+#     write_to_log(seqret.stderr, logger)
+
 def convert_gff_to_gbk(fasta_input, out_dir, prefix, logger):
     gff_file = os.path.join(out_dir, prefix + ".gff")
     out_pref = os.path.join(out_dir, prefix)
-    seqret = sp.Popen(["seqret", "-sequence", fasta_input, "-feature", "-fformat", "gff", "-fopenfile", gff_file, "-osformat", "genbank", "-osname_outseq", out_pref, "-auto"], stderr=sp.PIPE)
-    write_to_log(seqret.stderr, logger)
-
+    with open(out_pref, "wt") as gbk_handler:
+        fasta_handler = SeqIO.to_dict(SeqIO.parse(fasta_input, "fasta"))
+        for record in GFF.parse(gff_file, fasta_handler):
+            record.annotations["molecule_type"] = "DNA"
+            SeqIO.write(record, gbk_handler, "genbank")
 
 def run_minced(filepath_in, out_dir, prefix, logger):
     print("Running MinCED.")

--- a/bin/processes.py
+++ b/bin/processes.py
@@ -169,8 +169,8 @@ def run_mmseqs(db_dir, out_dir, threads, logger, gene_predictor, evalue):
 
 def convert_gff_to_gbk(fasta_input, out_dir, prefix, logger):
     gff_file = os.path.join(out_dir, prefix + ".gff")
-    out_pref = os.path.join(out_dir, prefix)
-    with open(out_pref, "wt") as gbk_handler:
+    gbk_file = os.path.join(out_dir, prefix + ".gbk")
+    with open(gbk_file, "wt") as gbk_handler:
         fasta_handler = SeqIO.to_dict(SeqIO.parse(fasta_input, "fasta"))
         for record in GFF.parse(gff_file, fasta_handler):
             record.annotations["molecule_type"] = "DNA"

--- a/bin/processes.py
+++ b/bin/processes.py
@@ -161,12 +161,6 @@ def run_mmseqs(db_dir, out_dir, threads, logger, gene_predictor, evalue):
     sp.run(["rm", "-r", target_db_dir], check=True)
 
 
-# def convert_gff_to_gbk(fasta_input, out_dir, prefix, logger):
-#     gff_file = os.path.join(out_dir, prefix + ".gff")
-#     out_pref = os.path.join(out_dir, prefix)
-#     seqret = sp.Popen(["seqret", "-sequence", fasta_input, "-feature", "-fformat", "gff", "-fopenfile", gff_file, "-osformat", "genbank", "-osname_outseq", out_pref, "-auto"], stderr=sp.PIPE)
-#     write_to_log(seqret.stderr, logger)
-
 def convert_gff_to_gbk(fasta_input, out_dir, prefix, logger):
     gff_file = os.path.join(out_dir, prefix + ".gff")
     gbk_file = os.path.join(out_dir, prefix + ".gbk")

--- a/build/meta.yaml
+++ b/build/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   - prodigal>=2.6.3
   - minced>=0.4.2
   - aragorn>=1.2.41
-  - bcbio-gff == 0.6.9
+  - bcbio-gff >= 0.6.9
 
 test:
   commands:

--- a/build/meta.yaml
+++ b/build/meta.yaml
@@ -22,7 +22,6 @@ requirements:
   - mmseqs2>=13.45111
   - trnascan-se>=2.0.9
   - hhsuite>=3.3.0
-  - emboss>=6.6.0
   - prodigal>=2.6.3
   - minced>=0.4.2
   - aragorn>=1.2.41

--- a/build/meta.yaml
+++ b/build/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   - prodigal>=2.6.3
   - minced>=0.4.2
   - aragorn>=1.2.41
+  - bcbio-gff == 0.6.9
 
 test:
   commands:

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - prodigal>=2.6.3
   - minced>= 0.4.2
   - aragorn>=1.2.41
-  - bcbio-gff == 0.6.9
+  - bcbio-gff >= 0.6.9

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - phanotate>=1.5.0
   - mmseqs2>=13.45111
   - trnascan-se>=2.0.9
-  - emboss>=6.6.0
   - prodigal>=2.6.3
   - minced>= 0.4.2
   - aragorn>=1.2.41

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - prodigal>=2.6.3
   - minced>= 0.4.2
   - aragorn>=1.2.41
+  - bcbio-gff == 0.6.9


### PR DESCRIPTION
Hi @gbouras13 

Thanks for your work on pharokka. It seems like a very promising program. I noticed that the processing function to convert `gff` to `gbk` is being done with `emboss`, which is a heavy program for just one function. Then, I thought that a light custom function based on biopython could make it as well. It also uses the bcbio-gff library. 

Thanks.