### PR TITLE
Allow for non standard translation table

### DIFF
--- a/bin/input_commands.py
+++ b/bin/input_commands.py
@@ -17,8 +17,6 @@ v = __version__
 def get_input():
 	parser = argparse.ArgumentParser(description='pharokka: fast phage annotation program', formatter_class=RawTextHelpFormatter)
 	parser.add_argument('-i', '--infile', action="store", help='Input genome file in fasta format.')
-    parser.add_argument('--infilefaa', action="store", help='Input faa file instead of a fasta file')
-    parser.add_argument('--infilefna', action="store", help='Input fna file instead of a fasta file')
 	parser.add_argument('-o', '--outdir', action="store", help='Directory to write the output to.', default=os.path.join(os.getcwd(), "output/") )
 	parser.add_argument('-d', '--database', action="store", help='Database directory. If the databases have been installed in the default directory, this is not required. Otherwise specify the path.',  default='Default')
 	parser.add_argument('-t', '--threads', help="Number of threads. Defaults to 1.", action="store", default = str(1))

--- a/bin/input_commands.py
+++ b/bin/input_commands.py
@@ -17,6 +17,8 @@ v = __version__
 def get_input():
 	parser = argparse.ArgumentParser(description='pharokka: fast phage annotation program', formatter_class=RawTextHelpFormatter)
 	parser.add_argument('-i', '--infile', action="store", help='Input genome file in fasta format.')
+    parser.add_argument('--infilefaa', action="store", help='Input faa file instead of a fasta file')
+    parser.add_argument('--infilefna', action="store", help='Input fna file instead of a fasta file')
 	parser.add_argument('-o', '--outdir', action="store", help='Directory to write the output to.', default=os.path.join(os.getcwd(), "output/") )
 	parser.add_argument('-d', '--database', action="store", help='Database directory. If the databases have been installed in the default directory, this is not required. Otherwise specify the path.',  default='Default')
 	parser.add_argument('-t', '--threads', help="Number of threads. Defaults to 1.", action="store", default = str(1))

--- a/bin/pharokka.py
+++ b/bin/pharokka.py
@@ -94,11 +94,7 @@ if __name__ == "__main__":
 
     # define input - overwrite if terminase reorienter is true
     
-    if args.infilefaa == True and args.infilefna == True:
-        input_faa = args.infilefaa
-        input_fna = args.infilefna
-    else:
-        input_fasta = args.infile    
+    input_fasta = args.infile    
         
     # terminase reorienting 
     if args.terminase == True:
@@ -127,26 +123,23 @@ if __name__ == "__main__":
         input_commands.instantiate_split_output(out_dir, args.meta)
     # CDS predicton
     
-    if args.infilefaa == True and args.infilefna == True:
-        logger.info("skipping annotation and using provided files")
-    else: 
     # phanotate 
-        if gene_predictor == "phanotate":
-            print("Running Phanotate.")
-            logger.info("Running Phanotate.")
-            if args.meta == True:
-                print("Applying meta mode.")
-                logger.info("Applying meta mode.")
-                processes.run_phanotate_fasta_meta(input_fasta, out_dir, args.threads, num_fastas)
-                processes.run_phanotate_txt_meta(input_fasta, out_dir, args.threads, num_fastas)
-                processes.concat_phanotate_meta(out_dir, num_fastas)
-            else:
-                processes.run_phanotate(input_fasta, out_dir, logger)
-        
-        if gene_predictor == "prodigal":
-            print("Implementing Prodigal using Pyrodigal.")
-            logger.info("Implementing Prodigal using Pyrodigal.")
-            processes.run_pyrodigal(input_fasta, out_dir,logger, args.meta, args.coding_table)
+    if gene_predictor == "phanotate":
+        print("Running Phanotate.")
+        logger.info("Running Phanotate.")
+        if args.meta == True:
+            print("Applying meta mode.")
+            logger.info("Applying meta mode.")
+            processes.run_phanotate_fasta_meta(input_fasta, out_dir, args.threads, num_fastas)
+            processes.run_phanotate_txt_meta(input_fasta, out_dir, args.threads, num_fastas)
+            processes.concat_phanotate_meta(out_dir, num_fastas)
+        else:
+            processes.run_phanotate(input_fasta, out_dir, logger)
+    
+    if gene_predictor == "prodigal":
+        print("Implementing Prodigal using Pyrodigal.")
+        logger.info("Implementing Prodigal using Pyrodigal.")
+        processes.run_pyrodigal(input_fasta, out_dir,logger, args.meta, args.coding_table)
     
     # translate fastas
     logger.info("Translating gene predicted fastas.")

--- a/bin/pharokka.py
+++ b/bin/pharokka.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
     # convert to genbank
     logger.info("Converting gff to genbank.")
     print("Converting gff to genbank.")
-    processes.convert_gff_to_gbk(input_fasta, out_dir, out_dir, prefix)
+    processes.convert_gff_to_gbk(input_fasta, out_dir, out_dir, prefix, args.coding_table)
     
 
     # update fasta headers and final output tsv

--- a/bin/pharokka.py
+++ b/bin/pharokka.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
     
     # translate fastas
     logger.info("Translating gene predicted fastas.")
-    processes.translate_fastas(out_dir,gene_predictor)
+    processes.translate_fastas(out_dir,gene_predictor,args.coding_table)
 
 
     # run trna-scan meta mode if required

--- a/bin/pharokka.py
+++ b/bin/pharokka.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     if args.infilefaa == True and args.infilefna == True:
         input_faa = args.infilefaa
         input_fna = args.infilefna
-    else
+    else:
         input_fasta = args.infile    
         
     # terminase reorienting 
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     
     if args.infilefaa == True and args.infilefna == True:
         logger.info("skipping annotation and using provided files")
-    else    
+    else: 
     # phanotate 
         if gene_predictor == "phanotate":
             print("Running Phanotate.")

--- a/bin/pharokka.py
+++ b/bin/pharokka.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
 
     # create gff and return locustag for table
     (locustag, locus_df, gff_df, total_gff) = post_processing.create_gff(cds_mmseqs_merge_df, length_df, input_fasta, out_dir, prefix, locustag, tmrna_flag, args.meta)
-    post_processing.create_tbl(cds_mmseqs_merge_df, length_df, out_dir, prefix, gene_predictor, tmrna_flag, gff_df)
+    post_processing.create_tbl(cds_mmseqs_merge_df, length_df, out_dir, prefix, gene_predictor, tmrna_flag, gff_df, args.coding_table)
 
 
     # output single gffs in meta mode

--- a/bin/pharokka.py
+++ b/bin/pharokka.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     # output single gffs in meta mode
     if args.split == True and args.meta == True:
         post_processing.create_gff_singles(length_df, input_fasta, out_dir, total_gff)
-        post_processing.convert_singles_gff_to_gbk(length_df, out_dir)
+        post_processing.convert_singles_gff_to_gbk(length_df, out_dir, args.coding_table)
         post_processing.split_fasta_singles(input_fasta, out_dir)
 
     # write vfdb and card tophits

--- a/bin/pharokka.py
+++ b/bin/pharokka.py
@@ -93,8 +93,13 @@ if __name__ == "__main__":
 
 
     # define input - overwrite if terminase reorienter is true
-    input_fasta = args.infile
-
+    
+    if args.infilefaa == True and args.infilefna == True:
+        input_faa = args.infilefaa
+        input_fna = args.infilefna
+    else
+        input_fasta = args.infile    
+        
     # terminase reorienting 
     if args.terminase == True:
         print("You have chosen to reorient your genome by specifying --terminase. Checking the input.")
@@ -120,25 +125,29 @@ if __name__ == "__main__":
         num_fastas = processes.split_input_fasta(input_fasta, out_dir)
         # will generate split output gffs if meta flag is true
         input_commands.instantiate_split_output(out_dir, args.meta)
-
     # CDS predicton
+    
+    if args.infilefaa == True and args.infilefna == True:
+        logger.info("skipping annotation and using provided files")
+    else    
     # phanotate 
-    if gene_predictor == "phanotate":
-        print("Running Phanotate.")
-        logger.info("Running Phanotate.")
-        if args.meta == True:
-            print("Applying meta mode.")
-            logger.info("Applying meta mode.")
-            processes.run_phanotate_fasta_meta(input_fasta, out_dir, args.threads, num_fastas)
-            processes.run_phanotate_txt_meta(input_fasta, out_dir, args.threads, num_fastas)
-            processes.concat_phanotate_meta(out_dir, num_fastas)
-        else:
-            processes.run_phanotate(input_fasta, out_dir, logger)
-    if gene_predictor == "prodigal":
-        print("Implementing Prodigal using Pyrodigal.")
-        logger.info("Implementing Prodigal using Pyrodigal.")
-        processes.run_pyrodigal(input_fasta, out_dir,logger, args.meta, args.coding_table)
-
+        if gene_predictor == "phanotate":
+            print("Running Phanotate.")
+            logger.info("Running Phanotate.")
+            if args.meta == True:
+                print("Applying meta mode.")
+                logger.info("Applying meta mode.")
+                processes.run_phanotate_fasta_meta(input_fasta, out_dir, args.threads, num_fastas)
+                processes.run_phanotate_txt_meta(input_fasta, out_dir, args.threads, num_fastas)
+                processes.concat_phanotate_meta(out_dir, num_fastas)
+            else:
+                processes.run_phanotate(input_fasta, out_dir, logger)
+        
+        if gene_predictor == "prodigal":
+            print("Implementing Prodigal using Pyrodigal.")
+            logger.info("Implementing Prodigal using Pyrodigal.")
+            processes.run_pyrodigal(input_fasta, out_dir,logger, args.meta, args.coding_table)
+    
     # translate fastas
     logger.info("Translating gene predicted fastas.")
     processes.translate_fastas(out_dir,gene_predictor)

--- a/bin/post_processing.py
+++ b/bin/post_processing.py
@@ -1224,7 +1224,7 @@ def create_gff_singles(length_df, fasta_input, out_dir,  total_gff):
 
 
 
-def convert_singles_gff_to_gbk(length_df, out_dir ):
+def convert_singles_gff_to_gbk(length_df, out_dir, coding_table):
     """
     Converts all single gffs to gbks
     :param length_df: a pandas df as output from get_contig_name_lengths()
@@ -1244,7 +1244,7 @@ def convert_singles_gff_to_gbk(length_df, out_dir ):
         # get the input fasta for each contig
         fasta_file = os.path.join(split_fasta_dir, "input_subprocess" + str(index+1) +".fasta" )
         contig = row['contig']
-        processes.convert_gff_to_gbk(fasta_file, single_gff_dir, single_gbk_dir, contig)
+        processes.convert_gff_to_gbk(fasta_file, single_gff_dir, single_gbk_dir, contig, coding_table)
 
 
 def split_fasta_singles(input_fasta, out_dir ):

--- a/bin/post_processing.py
+++ b/bin/post_processing.py
@@ -679,7 +679,7 @@ def write_tophits_vfdb_card(cds_mmseqs_merge_df, vfdb_results, card_results, loc
 
 
 
-def create_tbl(cds_mmseqs_df, length_df, out_dir, prefix, gene_predictor, tmrna_flag, gff_df):
+def create_tbl(cds_mmseqs_df, length_df, out_dir, prefix, gene_predictor, tmrna_flag, gff_df, coding_table):
     """
     Creates the pharokka.tbl file 
     :param cds_mmseqs_df: a pandas df as output from process_results()
@@ -756,7 +756,7 @@ def create_tbl(cds_mmseqs_df, length_df, out_dir, prefix, gene_predictor, tmrna_
                 f.write(start + "\t" + stop + "\t" + row['Region'] + "\n")
                 f.write(""+"\t"+""+"\t"+""+"\t"+"product" + "\t"+ str(row['annot']) + "\n")
                 f.write(""+"\t"+""+"\t"+""+"\t"+"locus_tag" + "\t"+ row['locus_tag'] + "\n")
-                f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ "11" + "\n")
+                f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ str(coding_table) + "\n")
             if trna_empty == False:
                 subset_trna_df = trna_df[trna_df['contig'] == contig]
                 for index, row in subset_trna_df.iterrows():
@@ -768,7 +768,7 @@ def create_tbl(cds_mmseqs_df, length_df, out_dir, prefix, gene_predictor, tmrna_
                     f.write(start + "\t" + stop + "\t" + row['Region'] + "\n")
                     f.write(""+"\t"+""+"\t"+""+"\t"+"product" + "\t"+ str(row['trna_product']) + "\n")
                     f.write(""+"\t"+""+"\t"+""+"\t"+"locus_tag" + "\t"+ row['locus_tag'] + "\n")
-                    f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ "11" + "\n")
+                    f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ str(coding_table) + "\n")
             if crispr_count > 0:
                 subset_crispr_df = crispr_df[crispr_df['contig'] == contig]
                 for index, row in subset_crispr_df.iterrows():
@@ -780,7 +780,7 @@ def create_tbl(cds_mmseqs_df, length_df, out_dir, prefix, gene_predictor, tmrna_
                     f.write(start + "\t" + stop + "\t" + row['Region'] + "\n")
                     f.write(""+"\t"+""+"\t"+""+"\t"+"locus_tag" + "\t"+ row['locus_tag'] + "\n")
                     f.write(""+"\t"+""+"\t"+""+"\t"+"product" + "\t"+ str(row['rpt_unit_seq']) + "\n")
-                    f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ "11" + "\n")
+                    f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ str(coding_table) + "\n")
             if tmrna_flag == True:
                 subset_tmrna_df = tmrna_df[tmrna_df['contig'] == contig]
                 for index, row in subset_tmrna_df.iterrows():
@@ -792,7 +792,7 @@ def create_tbl(cds_mmseqs_df, length_df, out_dir, prefix, gene_predictor, tmrna_
                     f.write(start + "\t" + stop + "\t" + 'tmRNA' + "\n")
                     f.write(""+"\t"+""+"\t"+""+"\t"+"locus_tag" + "\t"+ row['locus_tag'] + "\n")
                     f.write(""+"\t"+""+"\t"+""+"\t"+"product" + "\t"+ 'transfer-messenger RNA, SsrA' + "\n")
-                    f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ "11" + "\n")
+                    f.write(""+"\t"+""+"\t"+""+"\t"+"transl_table" + "\t"+ str(coding_table) + "\n")
 
 
 def remove_post_processing_files(out_dir, gene_predictor, meta):

--- a/bin/processes.py
+++ b/bin/processes.py
@@ -411,7 +411,7 @@ def run_mmseqs(db_dir, out_dir, threads, logger, gene_predictor, evalue):
     sp.run(["rm", "-r", target_db_dir], check=True)
 
 
-def convert_gff_to_gbk(filepath_in, input_dir, out_dir, prefix):
+def convert_gff_to_gbk(filepath_in, input_dir, out_dir, prefix, coding_table):
     """
     Converts the gff to genbank
     :param filepath_in: input fasta file
@@ -435,9 +435,9 @@ def convert_gff_to_gbk(filepath_in, input_dir, out_dir, prefix):
                 # add translation only if CDS
                 if feature.type == "CDS":
                     if feature.strand == 1:
-                        feature.qualifiers.update({'translation': Seq.translate(record.seq[feature.location.start.position:feature.location.end.position], to_stop=True)})
+                        feature.qualifiers.update({'translation': Seq.translate(record.seq[feature.location.start.position:feature.location.end.position], to_stop=True, table=coding_table)})
                     else: # reverse strand -1 needs reverse compliment
-                        feature.qualifiers.update({'translation': Seq.translate(record.seq[feature.location.start.position:feature.location.end.position].reverse_complement(), to_stop=True)})
+                        feature.qualifiers.update({'translation': Seq.translate(record.seq[feature.location.start.position:feature.location.end.position].reverse_complement(), to_stop=True, table=coding_table)})
             SeqIO.write(record, gbk_handler, "genbank")
 
 

--- a/bin/processes.py
+++ b/bin/processes.py
@@ -328,7 +328,7 @@ def tidy_prodigal_output(out_dir):
     return prod_filt_df
 
 
-def translate_fastas(out_dir, gene_predictor):
+def translate_fastas(out_dir, gene_predictor, coding_table):
     """
     Translates input CDSs to amino acids. For now will use 11 translation table. Will get around to alternative coding later
     :param out_dir: output directory
@@ -349,7 +349,7 @@ def translate_fastas(out_dir, gene_predictor):
         for dna_record in SeqIO.parse(os.path.join(out_dir, fasta_input_tmp), 'fasta'): 
             dna_header = str(clean_df['contig'].iloc[i]) + str(i) 
             dna_description = str(clean_df['start'].iloc[i]) + "_" + str(clean_df['stop'].iloc[i])
-            aa_record = SeqRecord(dna_record.seq.translate(to_stop=True), id=dna_header, description = dna_description )
+            aa_record = SeqRecord(dna_record.seq.translate(to_stop=True, table=coding_table),id=dna_header, description = dna_description )
             SeqIO.write(aa_record, aa_fa, 'fasta')
             i += 1
 


### PR DESCRIPTION
Fixed issue with gff/gbk generation defaulting to translation table 11 regardless of what argument was passed into pharokka.

Primarily through adding 'table = coding_table' to the Biopython translate function (without which it defaults to 11)

Output using translation table 4 in current version
![image](https://github.com/gbouras13/pharokka/assets/19933700/6cce542e-281a-42d5-9843-92bf4da32bf7)

Output using translation table 4 in pull request version
![image](https://github.com/gbouras13/pharokka/assets/19933700/1edbc3bb-e24a-424b-95c7-f20314a93b35)

note apologies for the multiple commits, was literally editing within github on the fly, which seemed to require a commit every time I wanted to open a different page/script
