### PR TITLE
logger has no attribute exit

### DIFF
--- a/bin/input_commands.py
+++ b/bin/input_commands.py
@@ -264,7 +264,7 @@ def check_duplicate_headers(fasta_file):
         if "#" in header:
             logger.error(
                 f"# character found in contig: {header} - please remove all '#' from your contig headers"
-            )  # errors if duplicate header found   
+            )  # errors if duplicate header found
         else:
             header_set.add(header)
     # if it finished it will be fine
@@ -414,7 +414,7 @@ def check_dependencies(skip_mash):
             break
     else:
         raise ValueError("MMseqs2 version not found")
-    
+
     # Ryan Wick's code from Dnaapler - for prebuilt binary on github
     if mmseqs_version.startswith("45111b6"):
         logger.info(f"MMseqs2 version found is {mmseqs_version}")
@@ -649,7 +649,7 @@ def validate_custom_hmm(filename):
     if filename.endswith(suffix) is True:
         logger.info(f"{filename} checked.")
     else:
-        logger.exit(
+        logger.error(
             f"{filename} does not end with .h3m . Please check your --custom_hmm parameter or use create_custom_hmm.py to create a custom HMM profile."
         )
 


### PR DESCRIPTION
I supplied an incorrect custom hmm (one with the suffix `.hmm`) 

And got this error message:
```
Traceback (most recent call last):
  File "/usr/local/bin/pharokka.py", line 489, in <module>
    main()
  File "/usr/local/bin/pharokka.py", line 116, in main
    validate_custom_hmm(args.custom_hmm)
  File "/usr/local/bin/input_commands.py", line 640, in validate_custom_hmm
    logger.exit(
AttributeError: 'Logger' object has no attribute 'exit'
```  